### PR TITLE
(SIMP-286) ClamAV can be fully disabled.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,5 +5,6 @@ fixtures:
     logrotate: "git://github.com/simp/pupmod-simp-logrotate"
     rsync: "git://github.com/simp/pupmod-simp-rsync"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
+    selinux: "git://github.com/simp/pupmod-simp-selinux"
   symlinks:
     clamav: "#{source_dir}"

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -6,3 +6,4 @@ fixtures:
     logrotate: "#{source_dir}/../logrotate"
     rsync: "#{source_dir}/../rsync"
     stdlib: "#{source_dir}/../stdlib"
+    selinux: "#{source_dir}/../selinux"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
@@ -7,17 +7,37 @@ gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[,
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  # FIXME: simp-rake-helpers should support Puppet 4.X
+  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first)) &&
+      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+    gem 'simp-rake-helpers'
+  end
+end
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem "beaker"
+  gem "beaker-rspec"
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,30 @@
+# More info at https://github.com/guard/guard#readme
+directories %w(lib test spec manifests) \
+  .select{|d| Dir.exists?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+guard 'rake', :task => 'test' do
+  watch(%r{^manifests\/(.+)\.pp$})
+  watch(%r{^spec\/(.+)\.rb$})
+end
+
+#### tmux 1.7+ can send rspec results to the TMUX status pane.
+notification( :tmux, {
+  display_message: true,
+  timeout: 5, # in seconds
+  default_message_format: '%s >> %s',
+  # the first %s will show the title, the second the message
+  # Alternately you can also configure *success_message_format*,
+  # *pending_message_format*, *failed_message_format*
+  line_separator: ' > ', # since we are single line we need a separator
+  color_location: 'status-left-bg', # to customize which tmux element will change color
+
+  # Other options:
+  default_message_color: 'black',
+  success: 'colour150',
+  failure: 'colour174',
+  pending: 'colour179',
+  # Notify on all tmux clients
+
+  display_on_all_clients: false
+}) if ( ENV.fetch( 'TMUX', false ) && (%x{tmux -V}.split(' ').last.split('.').last.to_i > 6 ))
+# vim:set syntax=ruby:

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,18 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
 
-# For playing nice with mock
-File.umask(027)
-
-require 'simp/rake/pkg'
-
+# These gems aren't always present, for instance
+# on Travis with --without development
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'puppet_blacksmith/rake_tasks'
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
 end
+
+
+# FIXME: move all this lint logic into simp-rake-helpers
+Rake::Task[:lint].clear
 
 # Lint Material
 begin
@@ -18,10 +21,58 @@ begin
   PuppetLint.configuration.send("disable_80chars")
   PuppetLint.configuration.send("disable_variables_not_enclosed")
   PuppetLint.configuration.send("disable_class_parameter_defaults")
+
+  PuppetLint.configuration.relative = true
+  PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+  #PuppetLint.configuration.fail_on_warnings = true
+
+  # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+  # http://puppet-lint.com/checks/class_parameter_defaults/
+  PuppetLint.configuration.send('disable_class_parameter_defaults')
+  # http://puppet-lint.com/checks/class_inherits_from_params_class/
+  PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+  exclude_paths = [
+    "bundle/**/*",
+    "pkg/**/*",
+    "dist/**/*",
+    "vendor/**/*",
+    "spec/**/*",
+  ]
+  PuppetLint.configuration.ignore_paths = exclude_paths
+  PuppetSyntax.exclude_paths = exclude_paths
 rescue LoadError
   puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+begin
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
+rescue LoadError
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
+
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-clamav.spec
+++ b/build/pupmod-clamav.spec
@@ -1,7 +1,7 @@
 Summary: ClamAV Puppet Module
 Name: pupmod-clamav
 Version: 4.1.0
-Release: 5
+Release: 6
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -56,6 +56,12 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Fri Aug 28 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.0-6
+- Added enable_clamav parameter to toggle: package install,
+  freshclam/clamscan cron jobs, clamav rsync, antivirus selboolean.
+- The clamav user, group now manageable and package name mutable.
+- Added validation to init.pp
+
 * Fri Feb 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-5
 - Updated to use the new 'simp' environment.
 - Changed calls directly to /etc/init.d/rsyslog to '/sbin/service rsyslog' so

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/set_schedule_spec.rb
+++ b/spec/classes/set_schedule_spec.rb
@@ -1,8 +1,26 @@
 require 'spec_helper'
 
 describe 'clamav::set_schedule' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts) do
+        facts
+      end
 
-  it { should create_class('clamav::set_schedule') }
-  it { should compile.with_all_deps }
-  it { should create_cron('clamscan') }
+      context "on #{os}" do
+        it { is_expected.to create_class('clamav::set_schedule') }
+        it { is_expected.to compile.with_all_deps }
+
+        context 'base' do
+          it { should create_cron('clamscan').with_ensure('present') }
+        end
+        context 'with enable_schedule => false' do
+          let (:params) {{
+            :enable_schedule => false
+          }}
+          it { should create_cron('clamscan').with_ensure('absent') }
+        end
+      end
+    end
+  end
 end

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,3 +1,4 @@
 ---
 rsync::server: 'test.example.domain'
 rsync::timeout: '2'
+client_nets : ['192.168.122.0/24']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,25 @@
-require 'pathname'
-require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet'
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
+
+require 'pathname'
 
 # RSpec Material
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
 
 # Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
 if Puppet.version < "4.0.0"
   Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
     $LOAD_PATH << lib_dir
   end
+end
+
+
+if !ENV.key?( 'TRUSTED_NODE_DATA' )
+  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
+  ENV['TRUSTED_NODE_DATA']='yes'
 end
 
 default_hiera_config =<<-EOM
@@ -20,33 +30,104 @@ default_hiera_config =<<-EOM
 :yaml:
   :datadir: "stub"
 :hierarchy:
-  # This is a variable that you can set in your test classes to ensure that the
-  # targeted YAML file gets loaded in the fixtures.
+  - "%{custom_hiera}"
   - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM
 
+# This can be used from inside your spec tests to set the testable environment.
+# You can use this to stub out an ENC.
+#
+# Example:
+#
+# context 'in the :foo environment' do
+#   let(:environment){:foo}
+#   ...
+# end
+#
+def set_environment(environment = :production)
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+end
+
+# This can be used from inside your spec tests to load custom hieradata within
+# any context.
+#
+# Example:
+#
+# describe 'some::class' do
+#   context 'with version 10' do
+#     let(:hieradata){ "#{class_name}_v10" }
+#     ...
+#   end
+# end
+#
+# Then, create a YAML file at spec/fixtures/hieradata/some__class_v10.yaml.
+#
+# Hiera will use this file as it's base of information stacked on top of
+# 'default.yaml' and <module_name>.yaml per the defaults above.
+#
+# Note: Any colons (:) are replaced with underscores (_) in the class name.
+def set_hieradata(hieradata)
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+end
+
+if not File.directory?(File.join(fixture_path,'hieradata')) then
+  FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
+end
+
+if not File.directory?(File.join(fixture_path,'modules',module_name)) then
+  FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
+end
+
 RSpec.configure do |c|
+  # If nothing else...
+  c.default_facts = {
+    :production => {
+      #:fqdn           => 'production.rspec.test.localdomain',
+      :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+      :concat_basedir => '/tmp'
+    }
+  }
+
   c.mock_framework = :rspec
+  c.mock_with :mocha
 
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
-  c.before(:all) do
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
+  # Useless backtrace noise
+  backtrace_exclusion_patterns = [
+    /spec_helper/,
+    /gems/
+  ]
 
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
+
+  c.before(:all) do
     data = YAML.load(default_hiera_config)
     data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
     File.open(c.hiera_config, 'w') do |f|
       f.write data.to_yaml
+    end
+  end
+
+  c.before(:each) do
+    if defined?(environment)
+      set_environment(environment)
+    end
+
+    if defined?(hieradata)
+      set_hieradata(hieradata.gsub(':','_'))
+    elsif defined?(class_name)
+      set_hieradata(class_name.gsub(':','_'))
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,58 @@
+require 'beaker-rspec'
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
+end
+
+# returns an Array of puppet modules declared in .fixtures.yml
+def pupmods_in_fixtures_yaml
+  require 'yaml'
+  fixtures_yml = File.expand_path( '../.fixtures.yml', File.dirname(__FILE__))
+  data         = YAML.load_file( fixtures_yml )
+  repos        = data.fetch('fixtures').fetch('repositories').keys
+  symlinks     = data.fetch('fixtures').fetch('symlinks', {}).keys
+  (repos + symlinks)
+end
+
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # net-tools required for netstat utility being used by be_listening
+    if fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7'
+      pp = <<-EOS
+        package { 'net-tools': ensure => installed }
+      EOS
+
+      apply_manifest_on(agents, pp, :catch_failures => false)
+    end
+
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'dummy')
+    hosts.each do |host|
+      # allow spec_prep to provide modules (to support isolated networks)
+      if ENV['BEAKER_use_fixtures_dir_for_modules'] == 'yes'
+        pupmods_in_fixtures_yaml.each do |pupmod|
+          mod_root = File.expand_path( "fixtures/modules/#{pupmod}", File.dirname(__FILE__))
+          puppet_module_install(:source => mod_root, :module_name => pupmod)
+        end
+      else
+        # TODO: update when the relevant SIMP modules are on the forge
+        on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added enable_clamav parameter to toggle: package install,
  freshclam/clamscan cron jobs, clamav rsync, antivirus selboolean.
- The clamav user, group now optionally manageable and package
  name mutable.
- Added validation to init.pp

SIMP-286 #close ClamAV disable.