### PR TITLE
(SIMP-3372) clamav - deps/changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.1-0
 - Updated logrotate to use new lastaction API
+- Update puppet dependency and remove OBE pe dependency in metadata.json
 
 * Thu Dec 13 2016 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Updated global catalysts

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -2,7 +2,7 @@ Obsoletes: pupmod-clamav-test
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
 Requires: pupmod-simp-logrotate < 7.0.0-0
-Requires: pupmod-simp-logrotate >= 6.0.0-0
+Requires: pupmod-simp-logrotate >= 6.1.0-0
 Requires: pupmod-simp-rsync >= 6.0.0-0
 Requires: pupmod-simp-rsync < 7.0.0-0
 Requires: pupmod-simp-simplib >= 3.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "simp/logrotate",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 7.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,7 +7,7 @@ describe 'clamav' do
       let(:facts) do
         facts
       end
-      let(:environment) {:production}
+      let(:environment) {'production'}
 
       context "on #{os}" do
         it { is_expected.to create_class('clamav') }


### PR DESCRIPTION
Requires newer version of logrotate.
Spec test fix for rspec-puppet