### PR TITLE
(SIMP-3739) Provide option to *not* manage rsync

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Sep 11 2017 Chris Tessmer <chris.tessmeri@onyxpoint.com> - 6.0.2-0
+- Permit clamav to disable both freshclam AND rsync updates
+
 * Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.1-0
 - Updated logrotate to use new lastaction API
 - Update puppet dependency and remove OBE pe dependency in metadata.json

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,13 @@
 #     The default targets are *extremely* conservative so you'll probably want to
 #     adjust this.
 #
+# @param rsync_source
+#    The rsync server source path for the clamav definitions.
+#    * Setting this parameter to an empty String will disable the clamav rsync.
+#
+# @param rsync_server
+#    The hostname of IP of the rsync server providing clamav definitions.
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class clamav (
@@ -104,13 +111,15 @@ class clamav (
       file { '/etc/cron.daily/freshclam': ensure => 'absent' }
 
       if $enable {
-        rsync { 'clamav':
-          source  => $rsync_source,
-          target  => '/var/lib/clamav',
-          server  => $rsync_server,
-          timeout => $rsync_timeout,
-          delete  => true,
-          require => Package[$package_name]
+        unless $rsync_source.empty() {
+          rsync { 'clamav':
+            source  => $rsync_source,
+            target  => '/var/lib/clamav',
+            server  => $rsync_server,
+            timeout => $rsync_timeout,
+            delete  => true,
+            require => Package[$package_name]
+          }
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-clamav",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "SIMP Team",
   "summary": "Safely manages clamav",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -63,6 +63,22 @@ describe 'clamav' do
           it { is_expected.not_to contain_rsync('clamav') }
         end
 
+        context 'with enable_freshclam => false' do
+          let(:params) {{
+            :enable_freshclam => false
+          }}
+          it { is_expected.to contain_file('/etc/cron.daily/freshclam').with_ensure('absent') }
+          it { is_expected.to contain_rsync('clamav') }
+
+          context 'and rsync_source is empty' do
+            let(:params) {{
+              :enable_freshclam => false,
+              :rsync_source => ''
+            }}
+            it { is_expected.to contain_file('/etc/cron.daily/freshclam').with_ensure('absent') }
+            it { is_expected.not_to contain_rsync('clamav') }
+          end
+        end
         context 'with enable => false' do
           let(:params) {{
             :enable => false


### PR DESCRIPTION
Before this update, if users opted out of distributing ClamAV updates
with freshclam, they were forced to distribute them using rsync.  It was
therefore impossible for existing SIMP 6.X users to provide their own
mechanisms for distributing updates without agent failures.

This patch fixes the issue by permitting users to disable ClamAV rsync
updates by providing the `rsync_source` parameter with an empty String.

SIMP-3739 #close
