### PR TITLE
(SIMP-6180) fix permissions so freshclam will run successfully

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri Mar 22 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.2-0
+- Fixed permissions on /var/simp/environments/simp/{rsync, rsync/Global,
+  rsync/Global/clamav so the clamav user can write to
+  rsync/Global/clamav.
+- Created new cron for when rsync is enabled.
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update URLs in the README.md

--- a/files/freshclam.rsync.cron
+++ b/files/freshclam.rsync.cron
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+### A simple update script for the clamav virus database.
+### This could as well be replaced by a SysV script.
+
+### fix log file if needed
+LOG_FILE="/var/log/clamav/freshclam.log"
+if [ ! -f "$LOG_FILE" ]; then
+    touch "$LOG_FILE"
+    chmod 644 "$LOG_FILE"
+    chown clam.clam "$LOG_FILE"
+fi
+
+/usr/bin/freshclam \
+    --quiet \
+    --datadir="/var/simp/environments/simp/rsync/Global/clamav" \
+    --log="$LOG_FILE"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,7 @@ class clamav (
           require => Package[$package_name]
         }
         file { '/etc/cron.daily/freshclam':
-          ensure => $_fresclam_ensure,
+          ensure => $_freshclam_ensure,
           owner  => 'root',
           group  => 'root',
           mode   => '0755',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-clamav",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": "SIMP Team",
   "summary": "Safely manages clamav",
   "license": "Apache-2.0",


### PR DESCRIPTION
The permissions on /var/lib/clamav were incorrect due to the permissions
on /var/simp/environments/simp/rsync/Global/clamav being incorrect. A
second cron was added for when $rsync_source.empty() is false.