### PR TITLE
(SIMP-6180) fix permissions so freshclam will run successfully

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Mar 22 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.2-0
+- Updated to manage permission of the rsync/Global/clamav folders
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update URLs in the README.md

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,8 @@ class clamav (
   Boolean       $manage_group_and_user = true,
   String        $clamav_user           = 'clam',
   String        $clamav_group          = 'clam',
+  String        $clamupdate_user       = 'clamupdate',
+  String        $clamupdate_group      = 'clamupdate',
   String        $package_name          = 'clamav',
   Boolean       $enable_freshclam      = false,
   Boolean       $schedule_scan         = true,
@@ -118,6 +120,21 @@ class clamav (
       file { '/etc/cron.daily/freshclam': ensure => 'absent' }
 
       if $enable {
+        file {'/var/simp/environments/simp/rsync':
+          ensure => 'directory',
+          mode   => '0755'
+        }
+        file {'/var/simp/environments/simp/rsync/Global':
+          ensure => 'directory',
+          mode   => '0755'
+        }
+        file { '/var/simp/environments/simp/rsync/Global/clamav':
+          ensure => 'directory',
+          owner  => $clamupdate_user,
+          group  => $clamupdate_group,
+          mode   => '0755'
+        }
+
         unless $rsync_source.empty() {
           rsync { 'clamav':
             source  => $rsync_source,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-clamav",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": "SIMP Team",
   "summary": "Safely manages clamav",
   "license": "Apache-2.0",


### PR DESCRIPTION
The permissions on /var/lib/clamav were incorrect due to the permissions
on /var/simp/environments/simp/rsync/Global/clamav being incorrect. When
clamav is enabled, it now manages permissions from rsync/ down.

Changes simplified from the last try. I was making things way more
complicated than they had to be.