### PR TITLE
(SIMP-7113) Remove clamav from default class list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 * Tue Oct 29 2019 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 6.4.0-0
-- Updated the README to clarify the use of simp_options::clamav.
-  and note that clamav was removed from the default class list
+- Updated the README to clarify what simp_options::clamav actually does
+  and to note that clamav was removed from the SIMP's default class list
   in SIMP 6.5.
-- Set the default for set_schedule::enable to lookup clamav::enable.
-  so it would remove clamav schedule if disabling clamav.
+- Set the default for clamav::set_schedule::enable to lookup clamav::enable,
+  so that class will remove the clamav schedule if clamav is disabled.
 
 * Tue Sep 24 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.4.0-0
 - Disable rsync pulls by default

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Oct 29 2019 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 6.4.0-0
+- Updated the README to clarify the use of simp_options::clamav.
+  and note that clamav was removed from the default class list
+  in SIMP 6.5.
+- Set the default for set_schedule::enable to lookup clamav::enable.
+  so it would remove clamav schedule if disabling clamav.
+
 * Tue Sep 24 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.4.0-0
 - Disable rsync pulls by default
 - Update README.md

--- a/README.md
+++ b/README.md
@@ -58,19 +58,19 @@ it can be used independently:
 
 The clamav module was removed from the  default class list in all simp scenarios
 in SIMP 6.5.
+Users of SIMP 6.5 or later must add clamav to the class list or include it via a manifest.
+
+The catalyst `simp_options::clamav` has been deprecated. It will be removed
+in future releases. It is still used as a wrapper for this module for
+backwards compatibility.  You must therefore have `simp_options::clamav` undefined
+or set to true for this module to do anything.
 
 Setting the SIMP catalyst, `simp_options::clamav`, to false does not
 uninstall ClamAV, it simply prevents this module from doing anything.
 These catalysts are used by SIMP to allow users to override default
 behavior of classes that are included by default.
 
-SIMP 6.5 removed clamav from the default list of classes.
 Users of SIMP 6.5 or later must add clamav to the class list or include it via a manifest.
-
-The catalyst `simp_options::clamav` has been deprecated. It will be removed
-in future releases. It is still used a wrapper for this module for
-backwards compatibility.  You must therefor have have `simp_options::clamav` undefined
-of set to true for this module to do anything.
 
 ## Using clamav
 

--- a/README.md
+++ b/README.md
@@ -54,22 +54,25 @@ it can be used independently:
 
   * If used independently, all SIMP-managed security subsystems are disabled by
     default and must be explicitly opted into by administrators.  Please review
-    the `simp-simp_options` module for details.
+    the `simp-simp_options` module for details.  These catalysts are used by
+    SIMP to allow users to override default behavior of classes that are
+    included by default.
 
-The clamav module was removed from the  default class list in all simp scenarios
-in SIMP 6.5.
-Users of SIMP 6.5 or later must add clamav to the class list or include it via a manifest.
+**NOTE:**
 
-The catalyst `simp_options::clamav` has been deprecated. It will be removed
-in future releases. It is still used as a wrapper for this module for
-backwards compatibility.  You must therefore have `simp_options::clamav` undefined
-or set to true for this module to do anything.
+* SIMP's `clamav` class was removed from the default class list in all SIMP
+  scenarios in SIMP 6.5.  Users of SIMP 6.5 or later must manually add `clamav`
+  to the class list or include it via a manifest.
 
-Setting the SIMP catalyst, `simp_options::clamav`, to false does not
-uninstall ClamAV, it simply prevents this module from doing anything.
-These catalysts are used by SIMP to allow users to override default
-behavior of classes that are included by default. See the ``using clamav``
-section below for how to remove clamav from the system.
+* Because of the SIMP 6.5 clamav change, SIMP's `simp_options::clamav` catalyst
+  has been deprecated and will be removed in a future release.  In the interim,
+  the catalyst is still used as a wrapper for this module for backwards
+  compatibility.  Therefore, you must have `simp_options::clamav` undefined or set
+  to `true` for this module to do anything.
+
+* Setting the SIMP catalyst, `simp_options::clamav`, to `false` does *not* uninstall
+  ClamAV, it simply prevents this module from doing anything.  See the
+  ``Using clamav`` section below for how to remove ClamAV from the system.
 
 ## Using clamav
 
@@ -83,6 +86,8 @@ include clamav
 
 By default this module will install ClamAV and set up a cron
 to do a scan.
+
+
 To remove ClamAV from the system set the following via Hiera:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -56,16 +56,34 @@ it can be used independently:
     default and must be explicitly opted into by administrators.  Please review
     the `simp-simp_options` module for details.
 
+The clamav module was removed from the  default class list in all simp scenarios
+in SIMP 6.5.
+
+Setting the SIMP catalyst, `simp_options::clamav`, to false does not
+uninstall ClamAV, it simply prevents this module from doing anything.
+These catalysts are used by SIMP to allow users to override default
+behavior of classes that are included by default.
+
+SIMP 6.5 removed clamav from the default list of classes.
+Users of SIMP 6.5 or later must add clamav to the class list or include it via a manifest.
+
+The catalyst `simp_options::clamav` has been deprecated. It will be removed
+in future releases. It is still used a wrapper for this module for
+backwards compatibility.  You must therefor have have `simp_options::clamav` undefined
+of set to true for this module to do anything.
 
 ## Using clamav
 
-To configure ClamAV to install and run:
+This module can be used to add or remove clamav from a system.
+
+To manage ClamAV with this module:
 
 ```puppet
 include clamav
 ```
 
-To remove clamav from the system, set the following via Hiera:
+By default this module will install and run ClamAV.
+To remove ClamAV from the system set the following via Hiera:
 
 ```yaml
 ---

--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ or set to true for this module to do anything.
 Setting the SIMP catalyst, `simp_options::clamav`, to false does not
 uninstall ClamAV, it simply prevents this module from doing anything.
 These catalysts are used by SIMP to allow users to override default
-behavior of classes that are included by default.
-
-Users of SIMP 6.5 or later must add clamav to the class list or include it via a manifest.
+behavior of classes that are included by default. See the ``using clamav``
+section below for how to remove clamav from the system.
 
 ## Using clamav
 
@@ -82,7 +81,8 @@ To manage ClamAV with this module:
 include clamav
 ```
 
-By default this module will install and run ClamAV.
+By default this module will install ClamAV and set up a cron
+to do a scan.
 To remove ClamAV from the system set the following via Hiera:
 
 ```yaml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,8 @@ class clamav (
 
   simplib::assert_metadata($module_name)
 
-  # If the catalyst is disabled, don't manage anything
+  # Setting simp_options::clamav to false disables this module and it will do nothing.
+  # It will not remove clamav from a system.  See README for more information.
   if simplib::lookup('simp_options::clamav', { 'default_value' =>  true }) {
 
     if $schedule_scan {

--- a/manifests/set_schedule.pp
+++ b/manifests/set_schedule.pp
@@ -42,7 +42,7 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class clamav::set_schedule (
-  Boolean                       $enable            = true,
+  Boolean                       $enable            = simplib::lookup('clamav::enable', { 'default_value' => true}),
   Simplib::Cron::Minute         $minute            = '32',
   Simplib::Cron::Hour           $hour              = '5',
   Simplib::Cron::MonthDay       $monthday          = '*',

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -68,6 +68,11 @@ describe 'clamav class' do
         it { is_expected.to be_file }
       }
 
+      it 'should create a crontab entry' do
+        stdout = on(client, 'crontab -l' ).stdout
+        expect(stdout).to include('/usr/bin/clamscan -l /var/log/clamscan.log')
+      end
+
       if on(client, '/usr/sbin/selinuxenabled', :accept_all_exit_codes => true).exit_code == 0
         it 'should have the selinux boolean "antivirus_can_scan_system" set' do
           result = on(client, '/usr/sbin/getsebool antivirus_can_scan_system')
@@ -97,6 +102,11 @@ describe 'clamav class' do
       describe file('/etc/cron.daily/freshclam') {
         it { is_expected.to_not be_file }
       }
+
+      it 'should not create a crontab entry' do
+        stdout = on(client, 'crontab -l' ).stdout
+        expect(stdout).not_to include('/usr/bin/clamscan -l /var/log/clamscan.log')
+      end
 
       if on(client, '/usr/sbin/selinuxenabled', :accept_all_exit_codes => true).exit_code == 0
         it 'should have the selinux boolean "antivirus_can_scan_system" set' do


### PR DESCRIPTION
- Updated the README to clarify the use of simp_options::clamav.
  and note that clamav was removed from the default class list
  in SIMP 6.5.
- Set the default for set_schedule::enable to lookup clamav::enable.
  so it would remove clamav schedule if disabling clamav.

SIMP-7113 #close
SIMP-7161 #close
SIMP-7163 #close