### PR TITLE
(SIMP-7708) Fix Gitab CI cache setting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,15 +1,16 @@
+# ------------------------------------------------------------------------------
+#             NOTICE: **This file is maintained with puppetsync**
+# ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
-# https://puppet.com/docs/pe/2019.0/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/2019.5/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.3      5.5.16   2.4.5  TBD***
-# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
-# PE 2019.0     6.0      2.5.1  2019-08-31^^^
-#
-# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
+# SIMP 6.4      5.5      2.4.5  TBD
+# PE 2018.1     5.5      2.4.5  2020-11 (LTS)
+# PE 2019.5     6.14     2.5.7  Quarterly
 ---
 stages:
   - 'sanity'
@@ -38,7 +39,6 @@ variables:
 # --------------------------------------
 .setup_bundler_env: &setup_bundler_env
   cache:
-    untracked: true
     key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
     paths:
       - '.vendor'
@@ -69,10 +69,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_16: &pup_5_5_16
+.pup_5_5_17: &pup_5_5_17
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.16'
+    PUPPET_VERSION: '5.5.17'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
@@ -149,25 +149,26 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.16-unit:
-  <<: *pup_5_5_16
+pup5.5.17-unit:
+  <<: *pup_5_5_17
   <<: *unit_tests
 
 pup6-unit:
   <<: *pup_6
   <<: *unit_tests
 
-# Acceptance tests
+# Repo-specific content
 # ==============================================================================
+
 # NOTE:  OEL nodes are included in the default nodeset
-pup5.5.16:
-  <<: *pup_5_5_16
+pup5.5.17:
+  <<: *pup_5_5_17
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup5.5.16-fips:
-  <<: *pup_5_5_16
+pup5.5.17-fips:
+  <<: *pup_5_5_17
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'


### PR DESCRIPTION
This patch removes the gitlab cache `untracked: true` setting from
`.gitlab-ci.yml`.

[SIMP-7708] #comment Update to latest pipeline in pupmod-simp-clamav
SIMP-7721 #close

[SIMP-7708]: https://simp-project.atlassian.net/browse/SIMP-7708