### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,7 +9,6 @@ HOSTS:
   el7:
     roles:
       - client
-      # roles migrated from now-removed el6 node(s): 
       - default
       - master
     platform: el-7-x86_64
@@ -25,7 +24,7 @@ HOSTS:
     roles:
       - client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       epel:

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -9,17 +9,11 @@ HOSTS:
   oel7:
     roles:
       - client
-      # roles migrated from now-removed el6 node(s): 
       - default
       - master
     platform:   el-7-x86_64
-    box:        onyxpoint/oel-7-x86_64
+    box:        generic/oracle7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   oel8:
     roles:
@@ -27,12 +21,7 @@ HOSTS:
     platform:   el-8-x86_64
     box:        generic/oracle8
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
-CONFIG:
+
 CONFIG:
   log_level: verbose
   type: aio


### PR DESCRIPTION
- update the EL8 nodes in the acceptance tests
  to run with generic/centos8 to make sure they using
  CentOS 8.4
- remove epel from repo list.  It is automatically added by linux-errata
  in beaker helpers

SIMP-10204 #comment clamav updated
SIMP-10211 #close