### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.6.0
+- Add RockyLinux 8 support
+
 * Tue Jun 15 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.5.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,7 +106,7 @@ class clamav (
     }
 
     # This is hackery to fix an update issue from the past.
-    if $facts['facts['os']['hardware']'] == 'x86_64' {
+    if $facts['os']['hardware'] == 'x86_64' {
       package { 'clamav.i386':
         ensure => 'absent',
         notify => Package['clamav-lib.i386']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class clamav (
   Boolean       $enable_data_rsync     = false,
   Boolean       $schedule_scan         = true,
   # This needs to allow empty strings for follow on logic
-  String        $rsync_source          = "clamav_${::environment}/",
+  String        $rsync_source          = "clamav_${facts['environment']}/",
   Simplib::Host $rsync_server          = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1' }),
   Integer       $rsync_timeout         = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => 2 }),
   String[1]     $package_ensure        = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
@@ -106,7 +106,7 @@ class clamav (
     }
 
     # This is hackery to fix an update issue from the past.
-    if $::hardwaremodel == 'x86_64' {
+    if $facts['facts['os']['hardware']'] == 'x86_64' {
       package { 'clamav.i386':
         ensure => 'absent',
         notify => Package['clamav-lib.i386']
@@ -142,7 +142,7 @@ class clamav (
       }
     }
 
-    if $facts['selinux_current_mode'] and $facts['selinux_current_mode'] != 'disabled' {
+    if $facts['os']['selinux']['current_mode'] and $facts['os']['selinux']['current_mode'] != 'disabled' {
       $_selboolean_value = $enable ? {true =>  'on', default => 'off'}
       selboolean { 'antivirus_can_scan_system':
         persistent => true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-clamav",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "author": "SIMP Team",
   "summary": "Safely manages clamav",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/logrotate",
@@ -48,6 +48,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.